### PR TITLE
ci: restrict some workflows to only run upstream

### DIFF
--- a/.github/workflows/check-release-osv.yml
+++ b/.github/workflows/check-release-osv.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   test-osv-scan:
     runs-on: ubuntu-latest
+    if: github.repository == 'mxmehl/latest-release-vulnerability-status'
     steps:
       - name: Checkout this repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.repository == 'mxmehl/latest-release-vulnerability-status'
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token


### PR DESCRIPTION
Adds `if: github.repository == '...'` condition to release-please and release-vulnerabilities workflows so they only run in the upstream repository, not in forks.